### PR TITLE
add(auth.controller): Add simple static login method

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,16 +6,14 @@
 use Mix.Config
 
 # General application configuration
-config :elatrix,
-  ecto_repos: []
+config :elatrix, ecto_repos: []
 
 # Configures the endpoint
 config :elatrix, ElatrixWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "5K1gBsxPqcH5c8GWVrrtuNUAAwyUbRy7iINEQoJT+g7V8qYTBFv7Y8a6SP7i1wzF",
   render_errors: [view: ElatrixWeb.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: Elatrix.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: Elatrix.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger
 config :logger, :console,
@@ -24,4 +22,4 @@ config :logger, :console,
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/lib/elatrix/application.ex
+++ b/lib/elatrix/application.ex
@@ -9,7 +9,7 @@ defmodule Elatrix.Application do
     # Define workers and child supervisors to be supervised
     children = [
       # Start the endpoint when the application starts
-      supervisor(ElatrixWeb.Endpoint, []),
+      supervisor(ElatrixWeb.Endpoint, [])
       # Start your own worker by calling: Elatrix.Worker.start_link(arg1, arg2, arg3)
       # worker(Elatrix.Worker, [arg1, arg2, arg3]),
     ]

--- a/lib/elatrix/authorisation/authorisation.ex
+++ b/lib/elatrix/authorisation/authorisation.ex
@@ -1,14 +1,13 @@
 defmodule Elatrix.Authorisation do
-  def authorise(params) do
-    case params do
-      %{"type" => "m.login.password"} ->
-        case params do
-          %{"user" => "viva", "password" => "forever"} ->
-            {:ok, "@viva:noserver.org", "abc123", "nope"}
+  @auth_fields %{"type" => "", "login" => "", "password" => "", "token" => ""}
 
-          _ ->
-            {:error_forbidden}
-        end
+  def authorise(params) do
+    case Map.merge(@auth_fields, params) do
+      %{"type" => "m.login.password", "user" => "viva", "password" => "forever"} ->
+        {:ok, %{user_id: "@viva:noserver.org", access_token: "abc123", device_id: "nope"}}
+
+      %{"type" => "m.login.password"} ->
+        {:error_forbidden}
 
       %{"type" => "m.login.token"} ->
         {:error_not_implemented}

--- a/lib/elatrix/authorisation/authorisation.ex
+++ b/lib/elatrix/authorisation/authorisation.ex
@@ -1,0 +1,20 @@
+defmodule Elatrix.Authorisation do
+  def authorise(params) do
+    case params do
+      %{"type" => "m.login.password"} ->
+        case params do
+          %{"user" => "viva", "password" => "forever"} ->
+            {:ok, "@viva:noserver.org", "abc123", "nope"}
+
+          _ ->
+            {:error_forbidden}
+        end
+
+      %{"type" => "m.login.token"} ->
+        {:error_not_implemented}
+
+      _ ->
+        {:error_auth_bad_type}
+    end
+  end
+end

--- a/lib/elatrix_web/controllers/auth_controller.ex
+++ b/lib/elatrix_web/controllers/auth_controller.ex
@@ -5,9 +5,9 @@ defmodule ElatrixWeb.AuthController do
     res = Elatrix.Authorisation.authorise(params)
 
     case res do
-      {:ok, user_id, access_token, device_id} ->
+      {:ok, auth_data} ->
         render(conn, "login.json", %{
-          data: %{user_id: user_id, access_token: access_token, device_id: device_id}
+          data: auth_data
         })
 
       {:error_forbidden} ->

--- a/lib/elatrix_web/controllers/auth_controller.ex
+++ b/lib/elatrix_web/controllers/auth_controller.ex
@@ -1,0 +1,24 @@
+defmodule ElatrixWeb.AuthController do
+  use ElatrixWeb, :controller
+
+  def login(conn, params) do
+    res = Elatrix.Authorisation.authorise(params)
+
+    case res do
+      {:ok, user_id, access_token, device_id} ->
+        render(conn, "login.json", %{
+          data: %{user_id: user_id, access_token: access_token, device_id: device_id}
+        })
+
+      {:error_forbidden} ->
+        conn
+        |> put_status(403)
+        |> render("403.json", %{data: %{"errcode" => "M_FORBIDDEN"}})
+
+      _ ->
+        conn
+        |> put_status(400)
+        |> render("400.json", %{data: %{"errcode" => "M_UNKNOWN", "error" => "Bad login type."}})
+    end
+  end
+end

--- a/lib/elatrix_web/controllers/test_controller.ex
+++ b/lib/elatrix_web/controllers/test_controller.ex
@@ -2,6 +2,6 @@ defmodule ElatrixWeb.TestController do
   use ElatrixWeb, :controller
 
   def index(conn, _params) do
-    render conn, "index.json", %{data: %{a: "1"}}
+    render(conn, "index.json", %{data: %{a: "1"}})
   end
 end

--- a/lib/elatrix_web/endpoint.ex
+++ b/lib/elatrix_web/endpoint.ex
@@ -5,38 +5,46 @@ defmodule ElatrixWeb.Endpoint do
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
-  plug Plug.Static,
-    at: "/", from: :elatrix, gzip: false,
+  plug(
+    Plug.Static,
+    at: "/",
+    from: :elatrix,
+    gzip: false,
     only: ~w(css fonts images js favicon.ico robots.txt)
+  )
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
-    plug Phoenix.LiveReloader
-    plug Phoenix.CodeReloader
+    socket("/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket)
+    plug(Phoenix.LiveReloader)
+    plug(Phoenix.CodeReloader)
   end
 
-  plug Plug.RequestId
-  plug Plug.Logger
+  plug(Plug.RequestId)
+  plug(Plug.Logger)
 
-  plug Plug.Parsers,
+  plug(
+    Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Poison
+  )
 
-  plug Plug.MethodOverride
-  plug Plug.Head
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
-  plug Plug.Session,
+  plug(
+    Plug.Session,
     store: :cookie,
     key: "_elatrix_key",
     signing_salt: "6yG/K1nL"
+  )
 
-  plug ElatrixWeb.Router
+  plug(ElatrixWeb.Router)
 
   @doc """
   Callback invoked for dynamically configuring the endpoint.

--- a/lib/elatrix_web/router.ex
+++ b/lib/elatrix_web/router.ex
@@ -2,13 +2,13 @@ defmodule ElatrixWeb.Router do
   use ElatrixWeb, :router
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug(:accepts, ["json"])
   end
 
   scope "/", ElatrixWeb do
-    pipe_through :api
+    pipe_through(:api)
 
-    get "/", TestController, :index
+    get("/", TestController, :index)
+    post("/login", AuthController, :login)
   end
-
 end

--- a/lib/elatrix_web/views/auth_view.ex
+++ b/lib/elatrix_web/views/auth_view.ex
@@ -1,0 +1,15 @@
+defmodule ElatrixWeb.AuthView do
+  use ElatrixWeb, :view
+
+  def render("login.json", %{data: data}) do
+    data
+  end
+
+  def render("400.json", %{data: data}) do
+    data
+  end
+
+  def render("403.json", %{data: data}) do
+    data
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule Elatrix.Mixfile do
       app: :elatrix,
       version: "0.1.0",
       elixir: "~> 1.6-rc",
-      elixirc_paths: elixirc_paths(Mix.env),
-      compilers: [:phoenix, :gettext] ++ Mix.compilers,
-      start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end
@@ -25,7 +25,7 @@ defmodule Elatrix.Mixfile do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.
   #
@@ -40,5 +40,4 @@ defmodule Elatrix.Mixfile do
       {:cowboy, "~> 1.0"}
     ]
   end
-
 end

--- a/test/elatrix_web/controllers/auth_controller_test.exs
+++ b/test/elatrix_web/controllers/auth_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule ElatrixWeb.AuthControllerTest do
+  use ElatrixWeb.ConnCase
+
+  test "POST /login", %{conn: conn} do
+    conn = post(conn, "/login", %{})
+    assert %{"errcode" => "M_UNKNOWN", "error" => "Bad login type."} = json_response(conn, 400)
+  end
+
+  test "POST /login invalid type", %{conn: conn} do
+    conn = post(conn, "/login", %{"type" => "shoot"})
+    assert %{"errcode" => "M_UNKNOWN", "error" => "Bad login type."} = json_response(conn, 400)
+  end
+
+  test "POST /login type=m.login.password no more data", %{conn: conn} do
+    conn = post(conn, "/login", %{"type" => "m.login.password"})
+    assert %{"errcode" => "M_FORBIDDEN"} = json_response(conn, 403)
+  end
+
+  test "POST /login type=m.login.password empty data", %{conn: conn} do
+    conn = post(conn, "/login", %{"type" => "m.login.password", "user" => "", "password" => ""})
+    assert %{"errcode" => "M_FORBIDDEN"} = json_response(conn, 403)
+  end
+
+  test "POST /login type=m.login.password valid test data", %{conn: conn} do
+    conn =
+      post(conn, "/login", %{
+        "type" => "m.login.password",
+        "user" => "viva",
+        "password" => "forever"
+      })
+
+    assert %{"user_id" => "@viva:noserver.org", "access_token" => "abc123", "device_id" => "nope"} =
+             json_response(conn, 200)
+  end
+end

--- a/test/elatrix_web/controllers/test_controller_test.exs
+++ b/test/elatrix_web/controllers/test_controller_test.exs
@@ -1,8 +1,8 @@
-defmodule ElatrixWeb.PageControllerTest do
+defmodule ElatrixWeb.TestControllerTest do
   use ElatrixWeb.ConnCase
 
   test "GET /", %{conn: conn} do
-    conn = get conn, "/"
+    conn = get(conn, "/")
     assert %{"a" => "1"} = json_response(conn, 200)
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -29,5 +29,4 @@ defmodule ElatrixWeb.ConnCase do
   setup do
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
-
 end


### PR DESCRIPTION
Allows user to log in with static user/password fields and get a static test token.

Also run everything through `mix format`.