### PR TITLE
add(content_type_subs): Replace content type on requests to read as json

### DIFF
--- a/lib/elatrix_web/plug/content_type_subs.ex
+++ b/lib/elatrix_web/plug/content_type_subs.ex
@@ -1,0 +1,9 @@
+defmodule ElatrixWeb.Plug.ContentTypeSubs do
+  import Plug.Conn
+
+  def init(options), do: options
+
+  def call(%Plug.Conn{request_path: path} = conn, opts) do
+    put_req_header(conn, "content-type", "application/json")
+  end
+end

--- a/lib/elatrix_web/router.ex
+++ b/lib/elatrix_web/router.ex
@@ -2,10 +2,18 @@ defmodule ElatrixWeb.Router do
   use ElatrixWeb, :router
 
   pipeline :api do
+    plug(ElatrixWeb.Plug.ContentTypeSubs)
     plug(:accepts, ["json"])
+
+    plug(
+      Plug.Parsers,
+      parsers: [:json],
+      pass: ["application/json", "text/plain"],
+      json_decoder: Poison
+    )
   end
 
-  scope "/", ElatrixWeb do
+  scope "/_matrix/client/r0", ElatrixWeb do
     pipe_through(:api)
 
     get("/", TestController, :index)


### PR DESCRIPTION
Replace content type to "application/json" because Riot sends requests in "text/plain"

I was able to pass through login action with Riot client and get to next action (read status?):

<img width="1336" alt="screen shot 2018-04-22 at 11 57 21" src="https://user-images.githubusercontent.com/1702672/39093747-d09cb682-4624-11e8-935d-d616dd30fc84.png">


(@kirill-kruchkov)